### PR TITLE
Add atom parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ iex(1)>     yaml = """
 "  a: a\n  b: 1\n  c: true\n  d: ~\n  e: nil\n"
 iex(2)> YamlElixir.read_from_string yaml, atoms: true
 %{:f => :atom, "a" => "a", "b" => 1, "c" => true, "d" => nil, "e" => "nil"}
-
 ```
 
 Atoms are not garbage collected by BEAM, so be careful with this option, and

--- a/README.md
+++ b/README.md
@@ -65,6 +65,45 @@ iex(2)> YamlElixir.read_from_file path
 %{"a" => "a", "b" => 1, "c" => true, "d" => nil, "e" => []}
 ```
 
+### Support for atoms
+
+By default, all map keys are processed as strings, as are all bareword or quoted
+values. If you would prefer to autodetect keys and values that begin with `:` as
+atoms, this can be accomplished by passing `atoms: true` as an option to any of
+the `read_*` functions.
+
+```elixir
+iex(1)>     yaml = """
+...(1)>       a: a
+...(1)>       b: 1
+...(1)>       c: true
+...(1)>       d: ~
+...(1)>       e: nil,
+...(1)>       :f: :atom
+...(1)>     """
+"  a: a\n  b: 1\n  c: true\n  d: ~\n  e: nil\n"
+iex(2)> YamlElixir.read_from_string yaml, atoms: true
+%{:f => :atom, "a" => "a", "b" => 1, "c" => true, "d" => nil, "e" => "nil"}
+
+```
+
+Atoms are not garbage collected by BEAM, so be careful with this option, and
+don't use it with user-supplied input. One other caveat: if you enable
+autodetection of atoms, any string values entered (e.g.,
+`":not_really_an_atom"`) will be converted to atoms, as well. If you only need
+to support a few atom values, you _might_ be better off enabling yamerl's
+custom tag for atoms:
+
+```elixir
+:yamerl_app.set_param(:node_mods, [:yamerl_node_erlang_atom])
+```
+
+and then using the somewhat inconvenient syntax for it:
+
+```yaml
+atom_key: !<tag:yamerl,2012:atom> atom_value
+```
+
 You can find more examples in [`test` directory](https://github.com/KamilLelonek/yaml-elixir/blob/master/test/yaml_elixir_test.exs).
 
 ## Contribution

--- a/lib/yaml_elixir.ex
+++ b/lib/yaml_elixir.ex
@@ -3,32 +3,37 @@ defmodule YamlElixir do
     Supervisor.start_link(children, options)
   end
 
+  @yamerl_options [
+    detailed_constr: true,
+    str_node_as_binary: true,
+  ]
+
   defp children, do: []
   defp options,  do: [strategy: :one_for_one, name: YamlElixir.Supervisor]
 
-  def read_all_from_file(path) do
+  def read_all_from_file(path, options \\ []) do
     path
-      |> :yamerl_constr.file(detailed_constr: true)
-      |> YamlElixir.Mapper.process
+      |> :yamerl_constr.file(@yamerl_options)
+      |> YamlElixir.Mapper.process(options)
   end
 
-  def read_from_file(path) do
+  def read_from_file(path, options \\ []) do
     path
-      |> :yamerl_constr.file(detailed_constr: true)
+      |> :yamerl_constr.file(@yamerl_options)
       |> List.last
-      |> YamlElixir.Mapper.process
+      |> YamlElixir.Mapper.process(options)
   end
 
-  def read_all_from_string(string) do
+  def read_all_from_string(string, options \\ []) do
     string
-      |> :yamerl_constr.string(detailed_constr: true)
-      |> YamlElixir.Mapper.process
+      |> :yamerl_constr.string(@yamerl_options)
+      |> YamlElixir.Mapper.process(options)
   end
 
-  def read_from_string(string) do
+  def read_from_string(string, options \\ []) do
     string
-    |> :yamerl_constr.string(detailed_constr: true)
+    |> :yamerl_constr.string(@yamerl_options)
     |> List.last
-    |> YamlElixir.Mapper.process
+    |> YamlElixir.Mapper.process(options)
   end
 end

--- a/lib/yaml_elixir/mapper.ex
+++ b/lib/yaml_elixir/mapper.ex
@@ -1,43 +1,50 @@
 defmodule YamlElixir.Mapper do
 
-  def process([]), do: [%{}]
-  def process(nil), do: %{}
+  def process([], _options), do: [%{}]
+  def process(nil, _options), do: %{}
 
-  def process(yaml) when is_list(yaml) do
-    yaml |> Enum.map(&process/1)
+  def process(yaml, options) when is_list(yaml) do
+    yaml |> Enum.map(&process(&1, options))
   end
 
-  def process(yaml) do
-    yaml |> _to_map |> extract_map
+  def process(yaml, options) do
+    yaml |> _to_map(options) |> extract_map
   end
 
   defp extract_map(nil), do: %{}
   defp extract_map(map), do: map
 
-  defp _to_map({:yamerl_doc, document}), do: _to_map(document)
+  defp _to_map({:yamerl_doc, document}, options), do: _to_map(document, options)
 
-  defp _to_map({ :yamerl_seq, :yamerl_node_seq, _tag, _loc, seq, _n }),
-  do:  Enum.map(seq, &_to_map(&1))
+  defp _to_map({ :yamerl_seq, :yamerl_node_seq, _tag, _loc, seq, _n }, options),
+  do:  Enum.map(seq, &_to_map(&1, options))
 
-  defp _to_map({ :yamerl_map, :yamerl_node_map, _tag, _loc, map_tuples }),
-  do:  _tuples_to_map(map_tuples, %{})
+  defp _to_map({ :yamerl_map, :yamerl_node_map, _tag, _loc, map_tuples }, options),
+  do:  _tuples_to_map(map_tuples, %{}, options)
 
-  defp _to_map({ :yamerl_str, :yamerl_node_str, _tag, _loc, elem }),
-  do:  to_string(elem)
+  defp _to_map({ :yamerl_str, :yamerl_node_str, _tag, _loc, << ?:, elem :: binary >> }, atoms: true) do
+    String.to_atom(elem)
+  end
 
-  defp _to_map({ :yamerl_null, :yamerl_node_null, _tag, _loc }),
-  do:  nil
-
-  defp _to_map({ _yamler_element, _yamler_node_element, _tag, _loc, elem }),
+  defp _to_map({ :yamerl_str, :yamerl_node_str, _tag, _loc, elem }, _options),
   do:  elem
 
-  defp _tuples_to_map([], map),
+  defp _to_map({ :yamerl_null, :yamerl_node_null, _tag, _loc }, _options),
+  do:  nil
+
+  defp _to_map(node = { _yamler_element, _yamler_node_element, _tag, _loc, elem }, _options), do: elem
+
+  defp _tuples_to_map([], map, _options),
   do:  map
 
-  defp _tuples_to_map([{ key, val } | rest], map) do
+  defp _tuples_to_map([{ key, val } | rest], map, options) do
     case key do
       { :yamerl_str, :yamerl_node_str, _tag, _log, name } ->
-         _tuples_to_map(rest, Dict.put_new(map, to_string(name), _to_map(val)))
+         _tuples_to_map(rest, Dict.put_new(map, key_for(name, options), _to_map(val, options)), options)
     end
   end
+
+  defp key_for(<< ?:, name :: binary >>, atoms: true), do: String.to_atom(name)
+
+  defp key_for(name, options), do: name
 end

--- a/lib/yaml_elixir/mapper.ex
+++ b/lib/yaml_elixir/mapper.ex
@@ -32,7 +32,7 @@ defmodule YamlElixir.Mapper do
   defp _to_map({ :yamerl_null, :yamerl_node_null, _tag, _loc }, _options),
   do:  nil
 
-  defp _to_map(node = { _yamler_element, _yamler_node_element, _tag, _loc, elem }, _options), do: elem
+  defp _to_map({ _yamler_element, _yamler_node_element, _tag, _loc, elem }, _options), do: elem
 
   defp _tuples_to_map([], map, _options),
   do:  map
@@ -46,5 +46,5 @@ defmodule YamlElixir.Mapper do
 
   defp key_for(<< ?:, name :: binary >>, atoms: true), do: String.to_atom(name)
 
-  defp key_for(name, options), do: name
+  defp key_for(name, _options), do: name
 end

--- a/test/fixtures/flat.yml
+++ b/test/fixtures/flat.yml
@@ -3,3 +3,4 @@ b: 1
 c: true
 d: ~
 e: []
+:f: :atom

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -10,7 +10,11 @@ defmodule YamlElixirTest do
   end
 
   test "should parse flat file" do
-    assert_parse_file "flat", %{"a" => "a", "b" => 1, "c" => true, "d" => nil, "e" => []}
+    assert_parse_file "flat", %{"a" => "a", "b" => 1, "c" => true, "d" => nil, "e" => [], ":f" => ":atom"}
+  end
+
+  test "should parse flat file with atoms option" do
+    assert_parse_file "flat", %{"a" => "a", "b" => 1, "c" => true, "d" => nil, "e" => [], :f => :atom}, atoms: true
   end
 
   test "should parse nested file" do
@@ -91,21 +95,21 @@ defmodule YamlElixirTest do
     File.cwd! |> Path.join("test/fixtures/#{file_name}.yml")
   end
 
-  defp assert_parse_multi_file(file_name, result) do
+  defp assert_parse_multi_file(file_name, result, options \\ []) do
     path = test_data(file_name)
-    assert YamlElixir.read_all_from_file(path) == result
+    assert YamlElixir.read_all_from_file(path, options) == result
   end
 
-  defp assert_parse_file(file_name, result) do
+  defp assert_parse_file(file_name, result, options \\ []) do
     path = test_data(file_name)
-    assert YamlElixir.read_from_file(path) == result
+    assert YamlElixir.read_from_file(path, options) == result
   end
 
-  defp assert_parse_multi_string(string, result) do
-    assert YamlElixir.read_all_from_string(string) == result
+  defp assert_parse_multi_string(string, result, options \\ []) do
+    assert YamlElixir.read_all_from_string(string, options) == result
   end
 
-  defp assert_parse_string(string, result) do
-    assert YamlElixir.read_from_string(string) == result
+  defp assert_parse_string(string, result, options \\ []) do
+    assert YamlElixir.read_from_string(string, options) == result
   end
 end


### PR DESCRIPTION
Hi there! I ran into a case where I really missed the Ruby YAML library's way of handling symbols with shorthand. This is an attempt to enable an (optional) feature for `yaml-elixir` that supports it. See the README updates for more info.

Thanks for your work!
