### PR TITLE
Add YamlElixir.Sigil

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ atom_key: !<tag:yamerl,2012:atom> atom_value
 
 ### Elixir Sigil
 
-The `YamlElixir.Sigils` module provides the `~y` sigil that
+The `YamlElixir.Sigil` module provides the `~y` sigil that
 can be useful for example for keeping short configurations
 or other inlined yaml.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,30 @@ and then using the somewhat inconvenient syntax for it:
 atom_key: !<tag:yamerl,2012:atom> atom_value
 ```
 
+### Elixir Sigils
+
+The `YamlElixir.Sigils` module provides the `~y` sigil that
+can be useful for example for keeping short configurations
+or other inlined yaml.
+
+```elixir
+import YamlElixir.Sigils
+
+@config ~y"""
+debug: false
+port:  9200
+files:
+  - some/file.csv
+  - another/file.csv
+"""
+```
+
+Use the `a` sigil modifier to turn on atom values from yaml:
+
+```
+~y":answer: yes"a
+```
+
 You can find more examples in [`test` directory](https://github.com/KamilLelonek/yaml-elixir/blob/master/test/yaml_elixir_test.exs).
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ and then using the somewhat inconvenient syntax for it:
 atom_key: !<tag:yamerl,2012:atom> atom_value
 ```
 
-### Elixir Sigils
+### Elixir Sigil
 
 The `YamlElixir.Sigils` module provides the `~y` sigil that
 can be useful for example for keeping short configurations
 or other inlined yaml.
 
 ```elixir
-import YamlElixir.Sigils
+import YamlElixir.Sigil
 
 @config ~y"""
 debug: false

--- a/lib/yaml_elixir/sigil.ex
+++ b/lib/yaml_elixir/sigil.ex
@@ -7,6 +7,4 @@ defmodule YamlElixir.Sigil do
   def sigil_y(string, []) do
     YamlElixir.read_from_string(string)
   end
-
-
 end

--- a/lib/yaml_elixir/sigil.ex
+++ b/lib/yaml_elixir/sigil.ex
@@ -1,0 +1,12 @@
+defmodule YamlElixir.Sigil do
+
+  def sigil_y(string, [?a]) do
+    YamlElixir.read_from_string(string, atoms: true)
+  end
+
+  def sigil_y(string, []) do
+    YamlElixir.read_from_string(string)
+  end
+
+
+end

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -91,6 +91,26 @@ defmodule YamlElixirTest do
     ]
   end
 
+  test "sigil should parse string document" do
+    import YamlElixir.Sigil
+    yaml = ~y"""
+    a: A
+    b: 1
+    """
+    assert %{"a" => "A", "b" => 1} == yaml
+  end
+
+  test "sigil with atom keys option" do
+    import YamlElixir.Sigil
+
+    yaml = ~y"""
+    a: :A
+    :b: 1
+    """a
+
+    assert %{"a" => :A, b: 1} == yaml
+  end
+
   defp test_data(file_name) do
     File.cwd! |> Path.join("test/fixtures/#{file_name}.yml")
   end


### PR DESCRIPTION
This changeset provides the `~y` elixir sigil that can be used for parsing inlined yaml.

``` elixir
import YamlElixir.Sigils

~y"""
some: value
from:
  - inlined
  - yaml
"""
```
