### PR TITLE
Update version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add `Yaml Elixir` as a dependency in your `mix.exs` file.
 defp deps do
   [
      # ...
-    { :yaml_elixir, "~> 1.0.0" },
+    { :yaml_elixir, "~> x.x.x" }, # where "x.x.x" equals version in mix.exs
     { :yamerl, github: "yakaz/yamerl" }
   ]
 end


### PR DESCRIPTION
Version in README was this

```
{ :yaml_elixir, "~> 1.0.0" }
```

Changed to this

```
{ :yaml_elixir, "~> x.x.x" }
```

Because this didn't work under v1.0.x

```
YamlElixir.read_from_string yaml, atoms: true
```
