### PR TITLE
Update deps to pull yamerl from Hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ defp deps do
   [
      # ...
     { :yaml_elixir, "~> x.x.x" }, # where "x.x.x" equals version in mix.exs
-    { :yamerl, github: "yakaz/yamerl" }
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule YamlElixir.Mixfile do
 
   defp deps do
     [
-      { :yamerl, github: "yakaz/yamerl" }
+      {:yamerl, "~> 0.3.2"}
     ]
   end
 


### PR DESCRIPTION
As noted in [this GitHub issue](https://github.com/yakaz/yamerl/issues/13), [yamerl has been published on Hex.pm](https://hex.pm/packages/yamerl).  I updated the README and `mix.exs` so that yamerl can be pulled from Hex, and not from GitHub.
