### PR TITLE
Update mix.lock for yamerl dependency.

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,1 @@
-%{"yamerl": {:git, "https://github.com/yakaz/yamerl.git", "ae810a808817d9482b4628ae3e20d746e3729fe0", []}}
+%{"yamerl": {:hex, :yamerl, "0.3.2", "9eac1537d251e926f47763ab1db0d9e6e8f2397646c290d58aa6ceebc6832fb7", [:rebar3], []}}


### PR DESCRIPTION
In #8 / cbd24d6 the yamerll dependency was switched from Github to
Hex as the source. The mix.lock wasn't included in the commit though.
