### PR TITLE
Fix: error when parsing a mapping between sequences

### DIFF
--- a/lib/yaml_elixir/mapper.ex
+++ b/lib/yaml_elixir/mapper.ex
@@ -35,6 +35,8 @@ defmodule YamlElixir.Mapper do
 
   defp _tuples_to_map([{ key, val } | rest], map, options) do
     case key do
+      { :yamerl_seq, :yamerl_node_seq, _tag, _log, _seq, _n } ->
+         _tuples_to_map(rest, Dict.put_new(map, _to_map(key, options), _to_map(val, options)), options)
       { _yamler_element, _yamler_node_element, _tag, _log, name } ->
          _tuples_to_map(rest, Dict.put_new(map, key_for(name, options), _to_map(val, options)), options)
     end

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -95,6 +95,23 @@ defmodule YamlElixirTest do
     ]
   end
 
+  test "should parse string with mapping between sequences" do
+    yaml = """
+    ---
+    ?
+      - a
+      - b
+    :
+      - 1
+      - 2
+    ? [c, d]
+    : [3, 4]
+    ? [e]
+    : 5
+    """
+    assert_parse_string yaml, %{["a", "b"] => [1, 2], ["c", "d"] => [3, 4], ["e"] => 5}
+  end
+
   test "sigil should parse string document" do
     import YamlElixir.Sigil
 


### PR DESCRIPTION
Error when parsing a complex mapping key.
