### PR TITLE
Remove Elixir 1.4 Warnings

### DIFF
--- a/lib/yaml_elixir.ex
+++ b/lib/yaml_elixir.ex
@@ -1,6 +1,6 @@
 defmodule YamlElixir do
   def start(_type, _args),
-    do: Supervisor.start_link(children, options)
+    do: Supervisor.start_link(children(), options())
 
   @yamerl_options [
     detailed_constr:    true,

--- a/lib/yaml_elixir/mapper.ex
+++ b/lib/yaml_elixir/mapper.ex
@@ -36,9 +36,9 @@ defmodule YamlElixir.Mapper do
   defp _tuples_to_map([{ key, val } | rest], map, options) do
     case key do
       { :yamerl_seq, :yamerl_node_seq, _tag, _log, _seq, _n } ->
-         _tuples_to_map(rest, Dict.put_new(map, _to_map(key, options), _to_map(val, options)), options)
+         _tuples_to_map(rest, Map.put_new(map, _to_map(key, options), _to_map(val, options)), options)
       { _yamler_element, _yamler_node_element, _tag, _log, name } ->
-         _tuples_to_map(rest, Dict.put_new(map, key_for(name, options), _to_map(val, options)), options)
+         _tuples_to_map(rest, Map.put_new(map, key_for(name, options), _to_map(val, options)), options)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule YamlElixir.Mixfile do
   def application() do
     [
       mod:          {YamlElixir, []},
-      applications: apps
+      applications: apps()
     ]
   end
 


### PR DESCRIPTION
This PR removes Elixir 1.4 'missing function parenthesis' warnings for zero-arity functions.  

Also changes "Dict" to "Map".  (Dict has been deprecated.)