### PR TITLE
Maps as keyword lists

### DIFF
--- a/lib/yaml_elixir/mapper.ex
+++ b/lib/yaml_elixir/mapper.ex
@@ -36,11 +36,7 @@ defmodule YamlElixir.Mapper do
   defp _tuples_to_map([], map, _options), do: map
 
   defp _tuples_to_map([{key, val} | rest], map, options) do
-    agregator_module =
-      case Keyword.get(options, :maps_as_keywords) do
-        true -> &append_kv/3
-        _ -> &Map.put_new/3
-      end
+    agregator_module = agregator_for_maps(options)
 
     case key do
       {:yamerl_seq, :yamerl_node_seq, _tag, _log, _seq, _n} ->
@@ -78,5 +74,12 @@ defmodule YamlElixir.Mapper do
 
   defp append_kv(list, key, value) do
     [{key, value} | list]
+  end
+
+  defp agregator_for_maps(options) do
+    case Keyword.get(options, :maps_as_keywords) do
+      true -> &append_kv/3
+      _ -> &Map.put_new/3
+    end
   end
 end

--- a/lib/yaml_elixir/mapper.ex
+++ b/lib/yaml_elixir/mapper.ex
@@ -1,15 +1,15 @@
 defmodule YamlElixir.Mapper do
-  def process(nil, _options), do: %{}
+  def process(nil, options), do: empty_container(options)
   def process(yaml, options) when is_list(yaml), do: Enum.map(yaml, &process(&1, options))
 
   def process(yaml, options),
     do:
       yaml
       |> _to_map(options)
-      |> extract_map()
+      |> extract_map(options)
 
-  defp extract_map(nil), do: %{}
-  defp extract_map(map), do: map
+  defp extract_map(nil, options), do: empty_container(options)
+  defp extract_map(map, _), do: map
 
   defp _to_map({:yamerl_doc, document}, options), do: _to_map(document, options)
 
@@ -17,7 +17,7 @@ defmodule YamlElixir.Mapper do
     do: Enum.map(seq, &_to_map(&1, options))
 
   defp _to_map({:yamerl_map, :yamerl_node_map, _tag, _loc, map_tuples}, options),
-    do: _tuples_to_map(map_tuples, %{}, options)
+    do: _tuples_to_map(map_tuples, empty_container(options), options)
 
   defp _to_map(
          {:yamerl_str, :yamerl_node_str, _tag, _loc, <<?:, elem::binary>> = original_elem},
@@ -36,18 +36,24 @@ defmodule YamlElixir.Mapper do
   defp _tuples_to_map([], map, _options), do: map
 
   defp _tuples_to_map([{key, val} | rest], map, options) do
+    agregator_module =
+      case Keyword.get(options, :maps_as_keywords) do
+        true -> &append_kv/3
+        _ -> &Map.put_new/3
+      end
+
     case key do
       {:yamerl_seq, :yamerl_node_seq, _tag, _log, _seq, _n} ->
         _tuples_to_map(
           rest,
-          Map.put_new(map, _to_map(key, options), _to_map(val, options)),
+          agregator_module.(map, _to_map(key, options), _to_map(val, options)),
           options
         )
 
       {_yamler_element, _yamler_node_element, _tag, _log, name} ->
         _tuples_to_map(
           rest,
-          Map.put_new(map, key_for(name, options), _to_map(val, options)),
+          agregator_module.(map, key_for(name, options), _to_map(val, options)),
           options
         )
     end
@@ -62,4 +68,15 @@ defmodule YamlElixir.Mapper do
   end
 
   defp key_for(name, _options), do: name
+
+  defp empty_container(options) do
+    case Keyword.get(options, :maps_as_keywords) do
+      true -> []
+      _ -> %{}
+    end
+  end
+
+  defp append_kv(list, key, value) do
+    [{key, value} | list]
+  end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "yamerl": {:hex, :yamerl, "0.7.0", "e51dba652dce74c20a88294130b48051ebbbb0be7d76f22de064f0f3ccf0aaf5", [:rebar3], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "yamerl": {:hex, :yamerl, "0.7.0", "e51dba652dce74c20a88294130b48051ebbbb0be7d76f22de064f0f3ccf0aaf5", [:rebar3], []},
 }

--- a/test/fixtures/nested_map.yml
+++ b/test/fixtures/nested_map.yml
@@ -1,0 +1,6 @@
+prod:
+  foo: foo
+  dev:
+    foo: bar
+  test:
+    foo: baz

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -168,6 +168,20 @@ defmodule YamlElixirTest do
     assert {:error, "malformed yaml"} = YamlElixir.read_from_file(path)
   end
 
+  # test "should receive keyword list when used `maps_as_keywords` option" do
+  #   assert_parse_file(
+  #     "nested",
+  #     [
+  #       [
+  #         {"prod", [{"foo", "foo"}]},
+  #         {"dev", [{"foo", "bar"}]},
+  #         {"test", [{"foo", "baz"}]}
+  #       ]
+  #     ],
+  #     maps_as_keywords: true
+  #   )
+  # end
+
   defp test_data(file_name), do: Path.join(File.cwd!(), "test/fixtures/#{file_name}.yml")
 
   defp assert_parse_multi_file(file_name, result, options \\ []) do

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -171,7 +171,7 @@ defmodule YamlElixirTest do
   test "should receive keyword list when used `maps_as_keywords` option" do
     assert_parse_file(
       "nested",
-      [[[{"prod", [{"foo", "foo"}]}, {"dev", [{"foo", "bar"}]}, {"test", [{"foo", "baz"}]}]]],
+      [{"test", [{"foo", "baz"}]}, {"dev", [{"foo", "bar"}]}, {"prod", [{"foo", "foo"}]}],
       maps_as_keywords: true
     )
   end

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -176,6 +176,14 @@ defmodule YamlElixirTest do
     )
   end
 
+  test "should receive keyword list of keyword lists when used `maps_as_keywords` option and parsing nested map" do
+    assert_parse_file(
+      "nested_map",
+      [{"prod", [{"test", [{"foo", "baz"}]}, {"dev", [{"foo", "bar"}]}, {"foo", "foo"}]}],
+      maps_as_keywords: true
+    )
+  end
+
   defp test_data(file_name), do: Path.join(File.cwd!(), "test/fixtures/#{file_name}.yml")
 
   defp assert_parse_multi_file(file_name, result, options \\ []) do

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -168,19 +168,13 @@ defmodule YamlElixirTest do
     assert {:error, "malformed yaml"} = YamlElixir.read_from_file(path)
   end
 
-  # test "should receive keyword list when used `maps_as_keywords` option" do
-  #   assert_parse_file(
-  #     "nested",
-  #     [
-  #       [
-  #         {"prod", [{"foo", "foo"}]},
-  #         {"dev", [{"foo", "bar"}]},
-  #         {"test", [{"foo", "baz"}]}
-  #       ]
-  #     ],
-  #     maps_as_keywords: true
-  #   )
-  # end
+  test "should receive keyword list when used `maps_as_keywords` option" do
+    assert_parse_file(
+      "nested",
+      [[[{"prod", [{"foo", "foo"}]}, {"dev", [{"foo", "bar"}]}, {"test", [{"foo", "baz"}]}]]],
+      maps_as_keywords: true
+    )
+  end
 
   defp test_data(file_name), do: Path.join(File.cwd!(), "test/fixtures/#{file_name}.yml")
 


### PR DESCRIPTION
* Removed code duplication in main file
* Fixed future bug with options (when there is more than one option convert to atom feature would crumble)
* Added `maps_as_keywords` feature