### PR TITLE
support return list when atom enable

### DIFF
--- a/lib/yaml_elixir/mapper.ex
+++ b/lib/yaml_elixir/mapper.ex
@@ -72,11 +72,18 @@ defmodule YamlElixir.Mapper do
   defp append_kv(list, key, value),
     do: [{key, value} | list]
 
+  defp append_list_kv(list, key, value),
+    do: list ++ [{String.to_atom(key), value}]
+
   defp maps_aggregator(options) do
-    with true <- Keyword.get(options, :maps_as_keywords) do
-      &append_kv/3
+    if Keyword.get(options, :maps_as_keywords) do
+      if Keyword.get(options, :atoms) do
+        &append_list_kv/3
+      else
+        &append_kv/3
+      end
     else
-      _ -> &Map.put_new/3
+      &Map.put_new/3
     end
   end
 end

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -132,6 +132,34 @@ defmodule YamlElixirTest do
     assert_parse_string(yaml, %{["a", "b"] => [1, 2], ["c", "d"] => [3, 4], ["e"] => 5})
   end
 
+  test "map list without atom" do
+    import YamlElixir.Sigil
+    yaml = """
+    ---
+    list:
+      - a: 1
+      - b: 2
+      - c: 3
+      - d: 4
+    """
+
+    assert_parse_string(yaml, %{"list" => [%{"a" => 1}, %{"b" => 2}, %{"c" => 3}, %{"d" => 4}]})
+  end
+
+  test "sigil list atom" do
+    import YamlElixir.Sigil
+    yaml = ~y"""
+    ---
+    list:
+      - a: 1
+      - b: 2
+      - c: 3
+      - d: 4
+    """a
+
+    %{"list" => [a: 1, b: 2, c: 1, d: 4]} == yaml
+  end
+
   test "sigil should parse string document" do
     import YamlElixir.Sigil
 


### PR DESCRIPTION
For this issue: #32 

Example yaml:
```yaml
list:
  - a: 1
  - b: 2
  - c: 3
  - d: 4
```

without `atom` flag:
```elixir
%{"list" => [%{"a" => 1}, %{"b" => 2}, %{"c" => 3}, %{"d" => 4}]}
```

with `atom` flag:
```elixir
%{"list" => [a: 1, b: 2, c: 1, d: 4]}
```