### PR TITLE
return exception structs in error tuples && raise on bang functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 erl_crash.dump
 *.ez
 /doc
-/.elixir_ls/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 erl_crash.dump
 *.ez
 /doc
+/.elixir_ls/

--- a/lib/yaml_elixir.ex
+++ b/lib/yaml_elixir.ex
@@ -6,6 +6,7 @@ defmodule YamlElixir do
     str_node_as_binary: true
   ]
 
+  @spec read_all_from_file!(any(), any()) :: any()
   def read_all_from_file!(path, options \\ []) do
     case read_all_from_file(path, options) do
       {:ok, result} -> result
@@ -13,9 +14,8 @@ defmodule YamlElixir do
     end
   end
 
-  def read_all_from_file(path, options \\ []) do
-    do_read(:file, path, options)
-  end
+  def read_all_from_file(path, options \\ []),
+    do: do_read(:file, path, options)
 
   def read_from_file!(path, options \\ []) do
     case read_from_file(path, options) do
@@ -24,9 +24,8 @@ defmodule YamlElixir do
     end
   end
 
-  def read_from_file(path, options \\ []) do
-    do_read(:file, path, Keyword.put(options, :one_result, true))
-  end
+  def read_from_file(path, options \\ []),
+    do: do_read(:file, path, Keyword.put(options, :one_result, true))
 
   def read_all_from_string!(string, options \\ []) do
     case read_all_from_string(string, options) do
@@ -35,9 +34,8 @@ defmodule YamlElixir do
     end
   end
 
-  def read_all_from_string(string, options \\ []) do
-    do_read(:string, string, options)
-  end
+  def read_all_from_string(string, options \\ []),
+    do: do_read(:string, string, options)
 
   def read_from_string!(string, options \\ []) do
     case read_from_string(string, options) do
@@ -46,9 +44,8 @@ defmodule YamlElixir do
     end
   end
 
-  def read_from_string(string, options \\ []) do
-    do_read(:string, string, Keyword.put(options, :one_result, true))
-  end
+  def read_from_string(string, options \\ []),
+    do: do_read(:string, string, Keyword.put(options, :one_result, true))
 
   defp do_read(type, source, options) do
     {:ok, prepare_and_read(type, source, options)}

--- a/lib/yaml_elixir.ex
+++ b/lib/yaml_elixir.ex
@@ -6,7 +6,6 @@ defmodule YamlElixir do
     str_node_as_binary: true
   ]
 
-  @spec read_all_from_file!(any(), any()) :: any()
   def read_all_from_file!(path, options \\ []) do
     case read_all_from_file(path, options) do
       {:ok, result} -> result

--- a/lib/yaml_elixir.ex
+++ b/lib/yaml_elixir.ex
@@ -6,40 +6,61 @@ defmodule YamlElixir do
     str_node_as_binary: true
   ]
 
-  def read_all_from_file!(path, options \\ []),
-    do: prepare_and_read(:file, path, options)
+  def read_all_from_file!(path, options \\ []) do
+    case read_all_from_file(path, options) do
+      {:ok, result} -> result
+      {:error, error} -> raise error
+    end
+  end
 
   def read_all_from_file(path, options \\ []) do
-    {:ok, read_all_from_file!(path, options)}
-  catch
-    _, _ -> {:error, "malformed yaml"}
+    do_read(:file, path, options)
   end
 
-  def read_from_file!(path, options \\ []),
-    do: prepare_and_read(:file, path, Keyword.put(options, :one_result, true))
+  def read_from_file!(path, options \\ []) do
+    case read_from_file(path, options) do
+      {:ok, result} -> result
+      {:error, error} -> raise error
+    end
+  end
 
   def read_from_file(path, options \\ []) do
-    {:ok, read_from_file!(path, options)}
-  catch
-    _, _ -> {:error, "malformed yaml"}
+    do_read(:file, path, Keyword.put(options, :one_result, true))
   end
 
-  def read_all_from_string!(string, options \\ []),
-    do: prepare_and_read(:string, string, options)
+  def read_all_from_string!(string, options \\ []) do
+    case read_all_from_string(string, options) do
+      {:ok, result} -> result
+      {:error, error} -> raise error
+    end
+  end
 
   def read_all_from_string(string, options \\ []) do
-    {:ok, read_all_from_string!(string, options)}
-  catch
-    _, _ -> {:error, "malformed yaml"}
+    do_read(:string, string, options)
   end
 
-  def read_from_string!(string, options \\ []),
-    do: prepare_and_read(:string, string, Keyword.put(options, :one_result, true))
+  def read_from_string!(string, options \\ []) do
+    case read_from_string(string, options) do
+      {:ok, result} -> result
+      {:error, error} -> raise error
+    end
+  end
 
   def read_from_string(string, options \\ []) do
-    {:ok, read_from_string!(string, options)}
+    do_read(:string, string, Keyword.put(options, :one_result, true))
+  end
+
+  defp do_read(type, source, options) do
+    {:ok, prepare_and_read(type, source, options)}
   catch
-    _, _ -> {:error, "malformed yaml"}
+    {:yamerl_exception, [{_, _, message, _, _, :file_open_failure, _, _}]} ->
+      {:error, %YamlElixir.FileNotFoundError{message: List.to_string(message)}}
+
+    {:yamerl_exception, [{_, _, message, _, _, :no_matching_anchor, _, _}]} ->
+      {:error, %YamlElixir.ParsingError{message: List.to_string(message)}}
+
+    _, _ ->
+      {:error, %YamlElixir.ParsingError{message: "malformed yaml"}}
   end
 
   defp prepare_and_read(type, source, options) do

--- a/lib/yaml_elixir/exceptions.ex
+++ b/lib/yaml_elixir/exceptions.ex
@@ -1,0 +1,7 @@
+defmodule YamlElixir.FileNotFoundError do
+  defexception message: "file error"
+end
+
+defmodule YamlElixir.ParsingError do
+  defexception message: "parsing error"
+end

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -134,6 +134,7 @@ defmodule YamlElixirTest do
 
   test "map list without atom" do
     import YamlElixir.Sigil
+
     yaml = """
     ---
     list:
@@ -148,6 +149,7 @@ defmodule YamlElixirTest do
 
   test "sigil list atom" do
     import YamlElixir.Sigil
+
     yaml = ~y"""
     ---
     list:
@@ -185,15 +187,45 @@ defmodule YamlElixirTest do
   test "should get error tuple for invalid literal" do
     yaml = "*invalid"
 
-    assert {:error, "malformed yaml"} = YamlElixir.read_all_from_string(yaml)
-    assert {:error, "malformed yaml"} = YamlElixir.read_from_string(yaml)
+    assert {:error, %YamlElixir.ParsingError{}} = YamlElixir.read_all_from_string(yaml)
+    assert {:error, %YamlElixir.ParsingError{}} = YamlElixir.read_from_string(yaml)
+  end
+
+  test "bang function should raise exception for invalid literal" do
+    yaml = "*invalid"
+
+    assert_raise YamlElixir.ParsingError, ~s(No anchor corresponds to alias "invalid"), fn ->
+      YamlElixir.read_all_from_string!(yaml)
+    end
   end
 
   test "should get error tuple for invalid file" do
     path = test_data("invalid")
 
-    assert {:error, "malformed yaml"} = YamlElixir.read_all_from_file(path)
-    assert {:error, "malformed yaml"} = YamlElixir.read_from_file(path)
+    assert {:error, %YamlElixir.ParsingError{}} = YamlElixir.read_all_from_file(path)
+    assert {:error, %YamlElixir.ParsingError{}} = YamlElixir.read_from_file(path)
+  end
+
+  test "bang function should raise exception for invalid file" do
+    path = test_data("invalid")
+
+    assert_raise YamlElixir.ParsingError, "malformed yaml", fn ->
+      YamlElixir.read_all_from_file!(path)
+    end
+  end
+
+  test "should get file error tuple for non-existent file" do
+    path = test_data("not_found")
+    assert {:error, %YamlElixir.FileNotFoundError{}} = YamlElixir.read_all_from_file(path)
+    assert {:error, %YamlElixir.FileNotFoundError{}} = YamlElixir.read_from_file(path)
+  end
+
+  test "bang function should raise exception for non-existent file" do
+    path = test_data("not_found")
+
+    assert_raise YamlElixir.FileNotFoundError, ~r/Failed to open file/, fn ->
+      YamlElixir.read_all_from_file!(path)
+    end
   end
 
   test "should receive keyword list when used `maps_as_keywords` option" do


### PR DESCRIPTION
https://github.com/KamilLelonek/yaml-elixir/issues/35

Returning `{:error, exception}` on non-bang functions so the user can decide whether to raise or not based on the type of exception and the message.

Exception types added:

- `YamlElixir.ParsingError`

- `YamlElixir.FileNotFoundError`

Bang functions raise Elixir exceptions instead of allowing `:yamerl` exceptions to be thrown.
