### PR TITLE
Improve Parsing Errors

### DIFF
--- a/lib/yaml_elixir.ex
+++ b/lib/yaml_elixir.ex
@@ -52,8 +52,8 @@ defmodule YamlElixir do
     {:yamerl_exception, [{_, _, message, _, _, :file_open_failure, _, _}]} ->
       {:error, %YamlElixir.FileNotFoundError{message: List.to_string(message)}}
 
-    {:yamerl_exception, [{_, _, message, _, _, :no_matching_anchor, _, _}]} ->
-      {:error, %YamlElixir.ParsingError{message: List.to_string(message)}}
+    {:yamerl_exception, [error | _]} ->
+      {:error, YamlElixir.ParsingError.from_yamerl(error)}
 
     _, _ ->
       {:error, %YamlElixir.ParsingError{message: "malformed yaml"}}

--- a/lib/yaml_elixir/exceptions.ex
+++ b/lib/yaml_elixir/exceptions.ex
@@ -6,14 +6,16 @@ defmodule YamlElixir.ParsingError do
   defexception [:line, :column, :type, message: "parsing error"]
 
   @impl true
-  def message(%__MODULE__{message: message, line: nil, column: nil}) do
-    message
-  end
+  def message(%__MODULE__{message: message, line: nil, column: nil}), do: message
+
   def message(%__MODULE__{message: message, line: line, column: column}) do
     message <> " (line: #{line}, column: #{column})"
   end
 
-  def from_yamerl({:yamerl_parsing_error, :error, human_readable_error, line, column, error_type, _token_being_parsed, _}) do
+  def from_yamerl(
+        {:yamerl_parsing_error, :error, human_readable_error, line, column, error_type,
+         _token_being_parsed, _}
+      ) do
     %__MODULE__{
       message: to_string(human_readable_error),
       line: line,
@@ -21,9 +23,6 @@ defmodule YamlElixir.ParsingError do
       type: error_type
     }
   end
-  def from_yamerl(_) do
-    %__MODULE__{
-      message: "malformed yaml"
-    }
-  end
+
+  def from_yamerl(_), do: %__MODULE__{message: "malformed yaml"}
 end

--- a/lib/yaml_elixir/exceptions.ex
+++ b/lib/yaml_elixir/exceptions.ex
@@ -3,5 +3,14 @@ defmodule YamlElixir.FileNotFoundError do
 end
 
 defmodule YamlElixir.ParsingError do
-  defexception message: "parsing error"
+  defexception [:line, :column, :type, message: "parsing error"]
+
+  def from_yamerl({:yamerl_parsing_error, :error, human_readable_error, line, column, error_type, _token_being_parsed, _}) do
+    %__MODULE__{
+      message: to_string(human_readable_error),
+      line: line,
+      column: column,
+      type: error_type
+    }
+  end
 end

--- a/lib/yaml_elixir/exceptions.ex
+++ b/lib/yaml_elixir/exceptions.ex
@@ -5,6 +5,14 @@ end
 defmodule YamlElixir.ParsingError do
   defexception [:line, :column, :type, message: "parsing error"]
 
+  @impl true
+  def message(%__MODULE__{message: message, line: nil, column: nil}) do
+    message
+  end
+  def message(%__MODULE__{message: message, line: line, column: column}) do
+    message <> " (line: #{line}, column: #{column})"
+  end
+
   def from_yamerl({:yamerl_parsing_error, :error, human_readable_error, line, column, error_type, _token_being_parsed, _}) do
     %__MODULE__{
       message: to_string(human_readable_error),

--- a/lib/yaml_elixir/exceptions.ex
+++ b/lib/yaml_elixir/exceptions.ex
@@ -13,4 +13,9 @@ defmodule YamlElixir.ParsingError do
       type: error_type
     }
   end
+  def from_yamerl(_) do
+    %__MODULE__{
+      message: "malformed yaml"
+    }
+  end
 end

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -144,14 +144,18 @@ defmodule YamlElixirTest do
       }
     """
 
-    assert_parse_string(json, %{
-      "a" => "a",
-      "b" => 1,
-      "c" => true,
-      "d" => nil,
-      "e" => "null",
-      "f" => 1.2
-    }, schema: :json)
+    assert_parse_string(
+      json,
+      %{
+        "a" => "a",
+        "b" => 1,
+        "c" => true,
+        "d" => nil,
+        "e" => "null",
+        "f" => 1.2
+      },
+      schema: :json
+    )
   end
 
   test "should parse nested json string" do
@@ -166,14 +170,18 @@ defmodule YamlElixirTest do
       }
     """
 
-    assert_parse_string(json, %{
-      "object" => %{
-        "string" => "value",
-        "null" => nil,
-        "number" => 1
+    assert_parse_string(
+      json,
+      %{
+        "object" => %{
+          "string" => "value",
+          "null" => nil,
+          "number" => 1
+        },
+        "array" => [1, 2, nil, "4"]
       },
-      "array" => [1, 2, nil, "4"]
-    }, schema: :json)
+      schema: :json
+    )
   end
 
   test "sigil should parse string document" do
@@ -206,22 +214,23 @@ defmodule YamlElixirTest do
   end
 
   test "exception structs should have line, column, and type values" do
-    yaml = "*invalid"
-    {:error, error} = YamlElixir.read_all_from_string(yaml)
+    {:error, error} = YamlElixir.read_all_from_string("*invalid")
 
     assert %YamlElixir.ParsingError{
-      line: 1,
-      column: 1,
-      type: :no_matching_anchor
-    } = error
+             line: 1,
+             column: 1,
+             type: :no_matching_anchor
+           } = error
   end
 
   test "bang function should raise exception for invalid literal" do
     yaml = "*invalid"
 
-    assert_raise YamlElixir.ParsingError, ~s/No anchor corresponds to alias "invalid" (line: 1, column: 1)/, fn ->
-      YamlElixir.read_all_from_string!(yaml)
-    end
+    assert_raise YamlElixir.ParsingError,
+                 ~s/No anchor corresponds to alias "invalid" (line: 1, column: 1)/,
+                 fn ->
+                   YamlElixir.read_all_from_string!(yaml)
+                 end
   end
 
   test "should get error tuple for invalid file" do
@@ -272,7 +281,12 @@ defmodule YamlElixirTest do
   test "should receive maps as keyword lists when map is tagged in the file" do
     assert_parse_file(
       "keyword_list",
-      %{"prod" => %{"foo" => [{"bar", "foo"}, {"foo", "bar"}], "bar" => %{"foo" => "bar", "bar" => "foo"}}},
+      %{
+        "prod" => %{
+          "foo" => [{"bar", "foo"}, {"foo", "bar"}],
+          "bar" => %{"foo" => "bar", "bar" => "foo"}
+        }
+      },
       node_mods: [YamlElixir.Node.KeywordList]
     )
   end

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -205,7 +205,7 @@ defmodule YamlElixirTest do
     assert {:error, %YamlElixir.ParsingError{}} = YamlElixir.read_from_string(yaml)
   end
 
-  test "errors should have line, column, and type values" do
+  test "exception structs should have line, column, and type values" do
     yaml = "*invalid"
     {:error, error} = YamlElixir.read_all_from_string(yaml)
 
@@ -219,7 +219,7 @@ defmodule YamlElixirTest do
   test "bang function should raise exception for invalid literal" do
     yaml = "*invalid"
 
-    assert_raise YamlElixir.ParsingError, ~s(No anchor corresponds to alias "invalid"), fn ->
+    assert_raise YamlElixir.ParsingError, ~s/No anchor corresponds to alias "invalid" (line: 1, column: 1)/, fn ->
       YamlElixir.read_all_from_string!(yaml)
     end
   end

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -205,6 +205,17 @@ defmodule YamlElixirTest do
     assert {:error, %YamlElixir.ParsingError{}} = YamlElixir.read_from_string(yaml)
   end
 
+  test "errors should have line, column, and type values" do
+    yaml = "*invalid"
+    {:error, error} = YamlElixir.read_all_from_string(yaml)
+
+    assert %YamlElixir.ParsingError{
+      line: 1,
+      column: 1,
+      type: :no_matching_anchor
+    } = error
+  end
+
   test "bang function should raise exception for invalid literal" do
     yaml = "*invalid"
 


### PR DESCRIPTION
This is an attempt to address: https://github.com/KamilLelonek/yaml-elixir/issues/46.

The underlying `yamerl` library returns useful information about the location and nature of Yaml errors.  With this PR we will now copy those into the `YamlElixir.ParsingError`s.

 