### PR TITLE
Merge Anchors on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,27 @@ Use the `a` sigil modifier to turn on atom values from YAML:
 
 You can find more examples in [`test` directory](https://github.com/KamilLelonek/yaml-elixir/blob/master/test/yaml_elixir_test.exs).
 
+### Merging anchors
+
+In case your YAML [contains anchors](http://blogs.perl.org/users/tinita/2019/05/reusing-data-with-yaml-anchors-aliases-and-merge-keys.html), you can have these resolved by passing `merge_anchors: true`:
+
+```elixir
+yaml = """
+yaml: 
+  foo: &foo
+    bar: 42
+  baz: 
+    << *foo
+"""
+YamlElixir.read_from_string(yaml, merge_anchors: true)
+```
+
+will result in
+
+```elixir
+%{ "yaml" => %{ "foo" => %{ "bar" => 42 }, "baz" => %{ "bar" => 42 } } }
+```
+
 ## Mix tasks
 
 Sometimes, you may want to use `yaml_elixir` in your `mix` tasks. To do that, you must ensure that the application has started.

--- a/lib/yaml_elixir/mapper.ex
+++ b/lib/yaml_elixir/mapper.ex
@@ -108,7 +108,7 @@ defmodule YamlElixir.Mapper do
   defp _merge_anchors(map) when is_map(map) do
     map
     |> Enum.reduce(%{}, fn {k, v}, acc ->
-      if k == "<<" || k == :"<<" do
+      if k == "<<" do
         acc |> Map.merge(v)
       else
         acc |> Map.put(k, _merge_anchors(v))

--- a/test/fixtures/simple_anchors.yml
+++ b/test/fixtures/simple_anchors.yml
@@ -1,0 +1,4 @@
+foo: &foo
+  bar: baz
+merged_foo:
+  <<: *foo

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -299,14 +299,15 @@ defmodule YamlElixirTest do
     )
   end
 
-  test "should merge keys for a file using anchors" do
+  test "should merge keys for a file using anchors when asked to" do
     assert_parse_file(
       "simple_anchors",
-      %{"foo" => %{"bar" => "baz"}, "merged_foo" => %{"bar" => "baz"}}
+      %{"foo" => %{"bar" => "baz"}, "merged_foo" => %{"bar" => "baz"}},
+      merge_anchors: true
     )
   end
 
-  test "should merge output for a string using anchors" do
+  test "should merge output for a string using anchors when asked to merge anchors" do
     yaml = """
     a: &a
       b: 42
@@ -315,7 +316,26 @@ defmodule YamlElixirTest do
      d: 43
     """
 
-    assert_parse_string(yaml, %{"a" => %{"b" => 42}, "c" => %{"b" => 42, "d" => 43}})
+    assert_parse_string(
+      yaml,
+      %{"a" => %{"b" => 42}, "c" => %{"b" => 42, "d" => 43}},
+      merge_anchors: true
+    )
+
+    yaml = """
+    a: &a
+      b: 42
+    c:
+      <<: *a
+      d: 43
+      b: 41
+    """
+
+    assert_parse_string(
+      yaml,
+      %{"a" => %{"b" => 42}, "c" => %{"b" => 41, "d" => 43}},
+      merge_anchors: true
+    )
   end
 
   defp test_data(file_name), do: Path.join(File.cwd!(), "test/fixtures/#{file_name}.yml")

--- a/test/yaml_elixir_test.exs
+++ b/test/yaml_elixir_test.exs
@@ -299,6 +299,25 @@ defmodule YamlElixirTest do
     )
   end
 
+  test "should merge keys for a file using anchors" do
+    assert_parse_file(
+      "simple_anchors",
+      %{"foo" => %{"bar" => "baz"}, "merged_foo" => %{"bar" => "baz"}}
+    )
+  end
+
+  test "should merge output for a string using anchors" do
+    yaml = """
+    a: &a
+      b: 42
+    c:
+     <<: *a
+     d: 43
+    """
+
+    assert_parse_string(yaml, %{"a" => %{"b" => 42}, "c" => %{"b" => 42, "d" => 43}})
+  end
+
   defp test_data(file_name), do: Path.join(File.cwd!(), "test/fixtures/#{file_name}.yml")
 
   defp assert_parse_multi_file(file_name, result, options \\ []) do


### PR DESCRIPTION
Hey,

I currently work on a project which needs to read a bit of YAML (some OpenAPIv3 specifications) and ran into #44. While digging into the `yamerl` parsing, I concluded that the behaviour is actually correct, but a little unsatisfying to work with.

I've patched the lib to allow for using an option to automatically merge anchors if so desired.
```elixir
yaml = """
a: &a
  b: 42
c:
  <<: *a
  d: 43
"""
# this branch
{:ok, %{"a" => %{"b" => 42}, "c" => %{"b" => 42, "d" => 43}}} = 
  yaml |> YamlElixir.read_from_string(merge_anchors: true)

# current behaviour in main
{:ok, %{"a" => %{"b" => 42}, "c" => %{"<<" => %{"b" => 42}, "d" => 43}}} = 
  yaml |> YamlElixir.read_from_string(merge_anchors: false)
```

The old behaviour is completely intact and is still the default, as to not break any existing clients.

Do you need me to update the README/docs/CHANGELOG?

Thanks a ton for providing this library!

Fixes #44.