### PR TITLE
Fix Elixir 1.20 unused require warnings

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.3.4
-elixir 1.17.3-otp-27
+elixir 1.20-otp-29
+erlang 29.0

--- a/lib/yaml_elixir/yaml_node_keyword_list.ex
+++ b/lib/yaml_elixir/yaml_node_keyword_list.ex
@@ -1,5 +1,4 @@
 defmodule YamlElixir.Node.KeywordList do
-  require Record
 
   import YamlElixir.Records, only: :macros
 


### PR DESCRIPTION
Remove unused `require Record` statement to resolve Elixir 1.20 compilation warnings.